### PR TITLE
feat : 분류 컴포넌트, 문서 보드 컴포넌트, 푸터 컴포넌트 퍼블리싱

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@
 import "./globals.css";
 import AppProvider from "@/provider";
 import Header from "@/components/Header";
+import Board from "@/components/Board";
+import Footer from "@/components/Footer";
 import { container } from "./layout.css";
 
 export default function RootLayout({
@@ -15,7 +17,10 @@ export default function RootLayout({
       <body>
         <AppProvider>
           <Header />
-          <div className={container}>{children}</div>
+          <div className={container}>
+            <Board>{children}</Board>
+          </div>
+          <Footer />
         </AppProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,12 @@
 import React from "react";
-import * as styles from "./page.css";
+import Classify from "@/components/Classify";
 
 const Home = () => {
-  return <div className={styles.container} />;
+  return (
+    <div>
+      <Classify />
+    </div>
+  );
 };
 
 export default Home;

--- a/components/Board/index.tsx
+++ b/components/Board/index.tsx
@@ -1,0 +1,28 @@
+import React, { PropsWithChildren } from "react";
+import Image from "next/image";
+import * as styles from "./style.css";
+
+const Board = ({ children }: PropsWithChildren) => {
+  return (
+    <div className={styles.container}>
+      <main className={styles.board}>{children}</main>
+      <div className={styles.subFooter}>
+        <Image
+          className={styles.subFooterLogo}
+          width={80}
+          height={54}
+          src="/assets/logoBlack.png"
+          alt="footer logo"
+        />
+        <span className={styles.subFooterNoticeText}>
+          부마위키는 공식 역사서 및 백과사전이 아니며 검증되지 않았거나,
+          편향적이거나, 잘못된 서술이 있을 수 있습니다.
+          <br />
+          질문이나 특정 사항에 대해 언제든지 문의주실 수 있습니다.
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default Board;

--- a/components/Board/style.css.ts
+++ b/components/Board/style.css.ts
@@ -1,0 +1,35 @@
+import { theme, flex, font } from "@/styles";
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+  width: "72vw",
+  ...flex.COLUMN_VERTICAL,
+  borderLeft: `2px solid ${theme.gray}`,
+  borderRight: `2px solid ${theme.gray}`,
+  backgroundColor: theme.white,
+});
+
+export const board = style({
+  width: "100%",
+  height: "fit-content",
+  minHeight: "100svh",
+  overflow: "hidden",
+  padding: "30px",
+  ...flex.COLUMN_FLEX,
+});
+
+export const subFooter = style({
+  width: "96%",
+  borderTop: `2px solid ${theme.gray}`,
+  padding: "10px 0",
+  ...flex.COLUMN_FLEX,
+});
+
+export const subFooterLogo = style({
+  marginLeft: "auto",
+});
+
+export const subFooterNoticeText = style({
+  ...font.H6,
+  textAlign: "right",
+});

--- a/components/Classify/index.tsx
+++ b/components/Classify/index.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import Link from "next/link";
+import * as styles from "./style.css";
+
+const Classify = () => {
+  return (
+    <Link href="/teacher" className={styles.container}>
+      분류 : <span className={styles.classify}>선생님</span>
+    </Link>
+  );
+};
+
+export default Classify;

--- a/components/Classify/style.css.ts
+++ b/components/Classify/style.css.ts
@@ -1,0 +1,15 @@
+import { theme, font } from "@/styles";
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+  width: "100%",
+  padding: "8px 14px",
+  border: `1px solid ${theme.gray}`,
+  borderRadius: "4px",
+  ...font.btn3,
+});
+
+export const classify = style({
+  color: theme.classify,
+  fontWeight: 500,
+});

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -15,7 +15,7 @@ const Footer = () => {
           <GithubIcon />
         </Link>
       </div>
-      <div className={styles.information}>
+      <div className={styles.informationBox}>
         <span className={styles.information}>
           buma.wiki | bumawiki@gmail.com | BSSM | TEAM OG | PROJECT BUMAWIKI
         </span>

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import Link from "next/link";
+import { GithubIcon } from "@/assets";
+import * as styles from "./style.css";
+
+const Footer = () => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.footerLinkBox}>
+        <Link
+          href="https://github.com/Team-INSERT"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <GithubIcon />
+        </Link>
+      </div>
+      <div className={styles.information}>
+        <span className={styles.information}>
+          buma.wiki | bumawiki@gmail.com | BSSM | TEAM OG | PROJECT BUMAWIKI
+        </span>
+      </div>
+      <div className={styles.informationBox}>
+        <span className={styles.information}>
+          1393, Garak-daero, Gangseo-gu, Busan, Republic of Korea
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default Footer;

--- a/components/Footer/style.css.ts
+++ b/components/Footer/style.css.ts
@@ -1,0 +1,32 @@
+import { font, flex } from "@/styles";
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+  width: "100vw",
+  height: "22vh",
+  backgroundColor: "#fff",
+  border: "1px solid #ccc",
+  ...flex.COLUMN_CENTER,
+});
+
+export const footerLinkBox = style({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: "10px 0",
+});
+
+export const separator = style({
+  margin: "0 20px 0 20px",
+  width: "2px",
+  height: "25px",
+  backgroundColor: "black",
+});
+
+export const informationBox = style({
+  marginTop: "12px",
+});
+
+export const information = style({
+  ...font.context,
+});


### PR DESCRIPTION
<!-- reviewers와 assignee는 설정하셨는지, label을 설정했는지 확인해주세요! -->

## Issue Number
close #11 
close #31 
close #12 
## What
부마위키 문서 보드와 푸터, 분류 컴포넌트를 개발했습니다.

## How
1. 기존에 서브푸터를 따로 직접 렌더링하던 구성방식을 변경하고, 문서보드 컴포넌트에 서브 푸터를 병합시켰습니다.
2. 인스타그램이 개설되지 않아 기존에 존재하던 인스타그램 로고를 삭제했습니다.
3. 페이지들의 app 레이아웃은 모두 부마위키 문서 보드 내에서 구성됩니다. 공통적으로 들어가는 분류 컴포넌트와 문서제목 (ex:부마위키:학생) 컴포넌트를 중복되는 코드 없이 어떻게 효율적으로 처리할 수 있는지를 논의해보아야합니다.

기본적으로 page 레이아웃 -> 앱 레이아웃으로 정보를 전달하여 분류 컴포넌트와 제목 컴포넌트가 바뀌는 상황이 제일 이상적이지만,
이를 위해 전역 컴포넌트를 라우팅마다 사용하는 것은 과하게 코드의 양이 늘어날 것이라는 우려를 했습니다.

어떤 방식으로 이 문제점을 해결해야할지에 대해서도 생각해보아야할 것 같습니다.
추가적인 의견 있으시면 comment와 함께 남겨주셔도 매우 도움될 것 같습니다!

## ScreenShot
<img width="1440" alt="스크린샷 2024-03-06 오후 5 13 34" src="https://github.com/Team-INSERT/BUMAWIKI_WEB_V3/assets/102154880/5935fe80-cfbd-4efe-950d-b7a204d9251d">
<img width="1438" alt="스크린샷 2024-03-06 오후 5 13 37" src="https://github.com/Team-INSERT/BUMAWIKI_WEB_V3/assets/102154880/b96f303b-9d6c-45c2-b721-ed0a22d40c55">
