### PR TITLE
style: 지역적인 global 속성들을 vanilla-extract로 변경

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,32 +88,3 @@ button {
   padding: 0;
   cursor: pointer;
 }
-
-.details > summary {
-  width: 100%;
-  height: 45px;
-  border-bottom: 1.5px solid #ccc;
-  margin: 10px 0;
-  font-weight: 800;
-  color: #27416894;
-  font-size: 30px;
-  cursor: pointer;
-  list-style: none;
-  display: flex;
-}
-
-.details[open] > summary {
-  color: #274168;
-}
-
-.details > summary:before {
-  content: "";
-  display: inline-block;
-  width: 40px;
-  height: 40px;
-  background: url("/assets/arrow_right.svg");
-}
-
-.details[open] > summary:before {
-  background: url("/assets/arrow_down.svg");
-}

--- a/components/Accordion/index.tsx
+++ b/components/Accordion/index.tsx
@@ -8,8 +8,8 @@ interface PropsType extends PropsWithChildren {
 const Accordion = ({ title, children }: PropsType) => {
   return (
     <div className={styles.container}>
-      <details className="details">
-        <summary>
+      <details className={styles.details}>
+        <summary className={styles.summary}>
           <div className={styles.title}>{title}</div>
         </summary>
         {children}

--- a/components/Accordion/style.css.ts
+++ b/components/Accordion/style.css.ts
@@ -1,3 +1,4 @@
+import { flex, theme } from "@/styles";
 import { style } from "@vanilla-extract/css";
 
 export const container = style({
@@ -8,4 +9,33 @@ export const container = style({
 export const title = style({
   textAlign: "center",
   lineHeight: "45px",
+});
+
+export const details = style({});
+
+export const summary = style({
+  width: "100%",
+  height: "45px",
+  borderBottom: `1.5px solid ${theme.gray}`,
+  margin: "10px 0",
+  fontWeight: 800,
+  color: theme.primary,
+  fontSize: "30px",
+  cursor: "pointer",
+  ...flex.FLEX,
+  selectors: {
+    [`${details}[open] > &`]: {
+      color: theme.primary,
+    },
+    [`${details} > &:before`]: {
+      content: "",
+      display: "inline-block",
+      width: "40px",
+      height: "40px",
+      background: "url('/assets/arrow_right.svg')",
+    },
+    [`${details}[open] > &:before`]: {
+      background: "url('/assets/arrow_down.svg')",
+    },
+  },
 });


### PR DESCRIPTION
<!-- reviewers와 assignee는 설정하셨는지, label을 설정했는지 확인해주세요! -->

## Issue Number

## What
기존에 일부 클래스들이 global.css를 참조하는 것을 제거하고, vanilla-extract를 사용하였습니다.
## How
- vanilla-extract의 selectors를 이용하여 작업하였습니다.
## ScreenShot
<img width="1710" alt="스크린샷 2024-03-07 오후 9 08 49" src="https://github.com/Team-INSERT/BUMAWIKI_WEB_V3/assets/128202921/4c347cc0-3b5c-4ea6-b967-617296c53e8a">
