### PR TITLE
fix : popular 페이지 -> 컴포넌트로 변경

### DIFF
--- a/app/layout.css.ts
+++ b/app/layout.css.ts
@@ -8,3 +8,12 @@ export const container = style({
   padding: "52px 20px 0 20px",
   ...flex.FLEX,
 });
+
+export const asideBox = style({
+  height: "100%",
+  position: "sticky",
+  top: "70px",
+  width: "300px",
+  gap: "12px",
+  ...flex.COLUMN_FLEX,
+});

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,8 @@ import Header from "@/components/Header";
 import Board from "@/components/Board";
 import Aside from "@/components/Aside";
 import Footer from "@/components/Footer";
-import { container } from "./layout.css";
+import Popular from "@/components/Popular";
+import * as styles from "./layout.css";
 import Providers from "./providers";
 
 export default function RootLayout({
@@ -16,9 +17,12 @@ export default function RootLayout({
       <body>
         <Providers>
           <Header />
-          <div className={container}>
+          <div className={styles.container}>
             <Board>{children}</Board>
-            <Aside />
+            <div className={styles.asideBox}>
+              <Popular />
+              <Aside />
+            </div>
           </div>
           <Footer />
         </Providers>

--- a/components/Aside/index.tsx
+++ b/components/Aside/index.tsx
@@ -35,20 +35,22 @@ const Aside = () => {
       <div className={styles.body}>
         <aside className={styles.container}>
           <div className={styles.titleBox}>
-            <span className={styles.titleText}>최근 수정된 문서</span>
+            <span className={styles.titleText}>최근 변경</span>
           </div>
-          {docsList?.map((docs: DocsListItem) => (
-            <Link
-              href={`/docs/${docs.title}`}
-              key={docs.id}
-              className={styles.docs}
-            >
-              <span className={styles.docsName}>{docs.title}</span>
-              <span className={styles.docsLastModified}>
-                {moment(docs.lastModifiedAt).fromNow()}
-              </span>
-            </Link>
-          ))}
+          <div className={styles.list}>
+            {docsList?.map((docs: DocsListItem) => (
+              <Link
+                href={`/docs/${docs.title}`}
+                key={docs.id}
+                className={styles.docs}
+              >
+                <span className={styles.docsName}>{docs.title}</span>
+                <span className={styles.docsLastModified}>
+                  {moment(docs.lastModifiedAt).fromNow()}
+                </span>
+              </Link>
+            ))}
+          </div>
         </aside>
         <div className={styles.pageBox}>
           <button

--- a/components/Aside/style.css.ts
+++ b/components/Aside/style.css.ts
@@ -2,19 +2,16 @@ import { style } from "@vanilla-extract/css";
 import { flex, font, theme } from "@/styles";
 
 export const body = style({
+  width: "300px",
+  height: "540px",
   ...flex.COLUMN_FLEX,
 });
 
 export const container = style({
-  position: "sticky",
-  width: "250px",
-  height: "502px",
   background: theme.white,
-  marginTop: "20px",
-  marginRight: "20px",
   border: `2px solid ${theme.gray}`,
+  height: "100%",
   borderTop: "none",
-  top: "74px",
 });
 
 export const titleBox = style({
@@ -33,6 +30,10 @@ export const titleText = style({
   ...font.H5,
 });
 
+export const list = style({
+  ...flex.COLUMN_FLEX,
+});
+
 export const docs = style({
   width: "100%",
   height: "38px",
@@ -45,6 +46,10 @@ export const docs = style({
 
   ":hover": {
     opacity: 0.8,
+  },
+
+  ":last-child": {
+    borderBottom: "none",
   },
 });
 

--- a/components/Board/style.css.ts
+++ b/components/Board/style.css.ts
@@ -2,7 +2,7 @@ import { theme, flex, font } from "@/styles";
 import { style } from "@vanilla-extract/css";
 
 export const container = style({
-  width: "80%",
+  width: "73%",
   ...flex.COLUMN_START,
   borderLeft: `2px solid ${theme.gray}`,
   borderRight: `2px solid ${theme.gray}`,

--- a/components/Board/style.css.ts
+++ b/components/Board/style.css.ts
@@ -7,7 +7,7 @@ export const container = style({
   borderLeft: `2px solid ${theme.gray}`,
   borderRight: `2px solid ${theme.gray}`,
   backgroundColor: theme.white,
-  margin: "0 40px",
+  margin: "0 20px 0 40px",
 });
 
 export const board = style({

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -6,7 +6,6 @@ import {
   AccidentIcon,
   ClubIcon,
   FrameIcon,
-  PopularIcon,
   StudentIcon,
   TeacherIcon,
   Logo,
@@ -22,7 +21,6 @@ const navigationList = [
   { item: "사건/사고", href: "/accident", icon: <AccidentIcon /> },
   { item: "동아리", href: "/club", icon: <ClubIcon /> },
   { item: "틀", href: "/frame", icon: <FrameIcon /> },
-  { item: "인기", href: "/popular", icon: <PopularIcon /> },
 ];
 
 const Header = () => {

--- a/components/Popular/index.tsx
+++ b/components/Popular/index.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { HydrationBoundary } from "@tanstack/react-query";
+import getQueryClient from "@/app/getQueryClient";
+import { docsQuery } from "@/services/docs/docsQuery";
+import { DocsListItem } from "@/types/docsListItem.interface";
+import Link from "next/link";
+import * as styles from "./style.css";
+
+const Popular = async () => {
+  const queryClient = getQueryClient();
+  const popularList = await queryClient.fetchQuery(
+    docsQuery.getList("popular"),
+  );
+
+  return (
+    <HydrationBoundary>
+      <div className={styles.body}>
+        <aside className={styles.container}>
+          <div className={styles.titleBox}>
+            <span className={styles.titleText}>실시간 인기</span>
+          </div>
+          <ul className={styles.docsList}>
+            {popularList
+              .slice(0, 10)
+              .map((popular: DocsListItem, index: number) => (
+                <li className={styles.docsListItem} key={popular.title}>
+                  <h1 className={styles.ranking}>{index + 1}</h1>
+                  <Link
+                    href={`/docs/${popular.title}`}
+                    className={styles.docsName}
+                  >
+                    {popular.title}
+                  </Link>
+                </li>
+              ))}
+          </ul>
+        </aside>
+      </div>
+    </HydrationBoundary>
+  );
+};
+
+export default Popular;

--- a/components/Popular/keyframes.css.ts
+++ b/components/Popular/keyframes.css.ts
@@ -1,0 +1,91 @@
+import { keyframes } from "@vanilla-extract/css";
+
+export const popularAnimation = keyframes({
+  "0%": {
+    transform: "translateY(44px)",
+  },
+
+  "2%": {
+    transform: "translateY(0)",
+  },
+
+  "8%": {
+    transform: "translateY(0)",
+  },
+
+  "10%": {
+    transform: "translateY(-44px)",
+  },
+
+  "18%": {
+    transform: "translateY(-44px)",
+  },
+
+  "20%": {
+    transform: "translateY(-88px)",
+  },
+
+  "28%": {
+    transform: "translateY(-88px)",
+  },
+
+  "30%": {
+    transform: "translateY(-132px)",
+  },
+
+  "38%": {
+    transform: "translateY(-132px)",
+  },
+
+  "40%": {
+    transform: "translateY(-176px)",
+  },
+
+  "48%": {
+    transform: "translateY(-176px)",
+  },
+
+  "50%": {
+    transform: "translateY(-220px)",
+  },
+
+  "58%": {
+    transform: "translateY(-220px)",
+  },
+
+  "60%": {
+    transform: "translateY(-264px)",
+  },
+
+  "68%": {
+    transform: "translateY(-264px)",
+  },
+
+  "70%": {
+    transform: "translateY(-308px)",
+  },
+
+  "78%": {
+    transform: "translateY(-308px)",
+  },
+
+  "80%": {
+    transform: "translateY(-352px)",
+  },
+
+  "88%": {
+    transform: "translateY(-352px)",
+  },
+
+  "90%": {
+    transform: "translateY(-396px)",
+  },
+
+  "98%": {
+    transform: "translateY(-396px)",
+  },
+
+  to: {
+    transform: "translateY(-440px)",
+  },
+});

--- a/components/Popular/style.css.ts
+++ b/components/Popular/style.css.ts
@@ -1,0 +1,65 @@
+import { keyframes, style } from "@vanilla-extract/css";
+import { flex, font, theme } from "@/styles";
+import { popularAnimation } from "./keyframes.css";
+
+export const body = style({
+  width: "300px",
+  height: "90px",
+  ...flex.COLUMN_FLEX,
+});
+
+export const container = style({
+  background: theme.white,
+  border: `2px solid ${theme.gray}`,
+  height: "100%",
+  borderTop: "none",
+  overflow: "hidden",
+});
+
+export const titleBox = style({
+  backgroundColor: theme.primary,
+  border: `2px solid ${theme.gray}`,
+  borderLeft: "none",
+  borderRight: "none",
+  width: "100%",
+  height: "46px",
+  ...flex.VERTICAL,
+});
+
+export const titleText = style({
+  marginLeft: "20px",
+  color: theme.white,
+  ...font.H5,
+});
+
+export const docsList = style({
+  overflow: "hidden",
+  ...flex.COLUMN_FLEX,
+});
+
+export const docsListItem = style({
+  width: "100%",
+  height: "44px",
+  padding: "0 16px",
+  gap: "12px",
+  animationDuration: "20s",
+  animationFillMode: "forwards",
+  animationIterationCount: "infinite",
+  animationName: popularAnimation,
+  animationTimingFunction: "ease-in-out",
+  cursor: "pointer",
+  ...flex.VERTICAL,
+});
+
+export const ranking = style({
+  ...font.H4,
+});
+
+export const docsName = style({
+  color: theme.primary,
+  ...font.H5,
+
+  ":hover": {
+    textDecoration: "underline",
+  },
+});

--- a/components/Popular/style.css.ts
+++ b/components/Popular/style.css.ts
@@ -1,4 +1,4 @@
-import { keyframes, style } from "@vanilla-extract/css";
+import { style } from "@vanilla-extract/css";
 import { flex, font, theme } from "@/styles";
 import { popularAnimation } from "./keyframes.css";
 

--- a/types/docsListItem.interface.ts
+++ b/types/docsListItem.interface.ts
@@ -4,4 +4,5 @@ export interface DocsListItem {
   enroll: number;
   docsType: string;
   lastModifiedAt: Date;
+  thumbsUpsCounts: number;
 }


### PR DESCRIPTION
<!-- reviewers와 assignee는 설정하셨는지, label을 설정했는지 확인해주세요! -->

## Issue Number
close #64 
## What
구글 애널리틱스를 통한 사용자 페이지 방문 횟수를 조회하니, popular 페이지의 리텐션이 낮다고 생각했습니다.
## How
최근수정된문서 위에 인기문서랭킹을 띄워주는식으로 변경했습니다. (현재는 1~10위까지 보입니다)
## ScreenShot
<img width="1439" alt="스크린샷 2024-03-11 오후 3 38 14" src="https://github.com/Team-INSERT/BUMAWIKI_WEB_V3/assets/102154880/85404cb2-dc79-4d4d-9210-60e8262bde6f">
