### PR TITLE
fix(accordion css): 누락된 색상값 추가

### DIFF
--- a/components/Accordion/style.css.ts
+++ b/components/Accordion/style.css.ts
@@ -18,7 +18,7 @@ export const summary = style({
   height: "45px",
   borderBottom: `1.5px solid ${theme.gray}`,
   margin: "10px 0",
-  color: theme.primary,
+  color: `${theme.primary}94`,
   cursor: "pointer",
   ...font.H2,
   ...flex.FLEX,


### PR DESCRIPTION
<!-- reviewers와 assignee는 설정하셨는지, label을 설정했는지 확인해주세요! -->

## Issue Number

## What
open일떄와 close일떄의 컬러값이 달라야 하는데 지난 PR에서 이부분이 누락되어 수정하였습니다.
## How
```color: `${theme.primary}94`,```
## ScreenShot
![image](https://github.com/Team-INSERT/BUMAWIKI_WEB_V3/assets/101105694/8a2496ba-8bf7-45e3-ac10-621a744bc0a3)
