### PR TITLE
fix : frame editor

### DIFF
--- a/components/Editor/Editor.tsx
+++ b/components/Editor/Editor.tsx
@@ -53,7 +53,10 @@ const Editor = memo(({ contents = "", title = "", docsType = "", mode }: EditorP
         component: (
           <Confirm
             content="변경 사항을 삭제하시겠습니까?"
-            onConfirm={() => setDocs((prev) => ({ ...prev, contents }))}
+            onConfirm={() => {
+              setDocs((prev) => ({ ...prev, contents }));
+              setIsChanged((prev) => !prev);
+            }}
           />
         ),
       });

--- a/components/FrameEditor/style.css.ts
+++ b/components/FrameEditor/style.css.ts
@@ -106,7 +106,6 @@ export const ColSpan = style({
   height: "100%",
   backgroundColor: theme.primary,
   cursor: "pointer",
-  zIndex: "20",
 
   ":hover": {
     backgroundColor: theme.btnHover,


### PR DESCRIPTION
<!-- reviewers와 assignee는 설정하셨는지, label을 설정했는지 확인해주세요! -->

## Issue Number

## What
rowSpan 변경 버튼이 z-index로인해 문법 예시 컴포넌트를 침범하는 문제가 있었습니다.
틀 문서는 되돌리기 기능이 제대로 반영되지 않는 문제가 있었습니다.

## How
z-index 속성을 제거하였습니다.
되돌리기 버튼 클릭시 틀 에디터에도 변경사항이 반영되도록 수정하였습니다.

## ScreenShot
![image](https://github.com/Team-INSERT/BUMAWIKI_WEB_V3/assets/101105694/b9598684-eb9d-463d-8d2c-423a5790c658)
