### PR TITLE
refactor : editor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     "react/react-in-jsx-scope": "off",
     "react/jsx-no-useless-fragment": 0,
     "react/jsx-key": 1,
+    "react/no-danger": 0,
     "react/button-has-type": 0,
     "@typescript-eslint/no-use-before-define": "off",
     "react/jsx-filename-extension": [1, { extensions: [".ts", ".tsx"] }], // should add ".ts" if typescript project

--- a/app/(docs)/docs/[title]/Docs.tsx
+++ b/app/(docs)/docs/[title]/Docs.tsx
@@ -93,11 +93,7 @@ const Docs: FC<{ title: string; list: string[] }> = ({ title, list }) => {
                     />
                   ),
               )}
-              <div
-                className={styles.body}
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={sanitizeData()}
-              />
+              <div className={styles.body} dangerouslySetInnerHTML={sanitizeData()} />
             </>
           )}
           <div className={styles.contributorsBox}>

--- a/app/coin/TradeHistory.css.ts
+++ b/app/coin/TradeHistory.css.ts
@@ -1,5 +1,6 @@
 import { flex, font, theme } from "@/styles";
-import { ComplexStyleRule, style, styleVariants } from "@vanilla-extract/css";
+import StyleVariantsType from "@/types/styleVariants.interface";
+import { style, styleVariants } from "@vanilla-extract/css";
 
 export const tradeListBox = style({
   width: "100%",
@@ -63,7 +64,7 @@ export const tradeStatusCircleBase = style({
   borderRadius: "999px",
 });
 
-export const tradeStatusCircle = styleVariants<Record<string, ComplexStyleRule>>({
+export const tradeStatusCircle = styleVariants<StyleVariantsType>({
   BUYING: [tradeStatusCircleBase, { backgroundColor: theme.insert }],
   SELLING: [tradeStatusCircleBase, { backgroundColor: theme.insert }],
   BOUGHT: [tradeStatusCircleBase, { backgroundColor: theme.buy }],

--- a/app/coin/rank/style.css.ts
+++ b/app/coin/rank/style.css.ts
@@ -1,5 +1,6 @@
 import { flex, font, theme } from "@/styles";
-import { ComplexStyleRule, style, styleVariants } from "@vanilla-extract/css";
+import StyleVariantsType from "@/types/styleVariants.interface";
+import { style, styleVariants } from "@vanilla-extract/css";
 
 export const rankingBox = style({
   width: "100%",
@@ -42,7 +43,7 @@ const rankingListItemRankTextBase = style({
   ...font.H4,
 });
 
-export const rankingListItemRankText = styleVariants<Record<string, ComplexStyleRule>>({
+export const rankingListItemRankText = styleVariants<StyleVariantsType>({
   1: [rankingListItemRankTextBase, { ...font.H2 }],
   2: [rankingListItemRankTextBase, { ...font.H3 }],
   default: [rankingListItemRankTextBase],
@@ -53,7 +54,7 @@ const rankingListItemNameTextBase = style({
   ...font.H5,
 });
 
-export const rankingListItemNameText = styleVariants<Record<string, ComplexStyleRule>>({
+export const rankingListItemNameText = styleVariants<StyleVariantsType>({
   1: [rankingListItemNameTextBase, { ...font.H3 }],
   2: [rankingListItemNameTextBase, { ...font.H4 }],
   default: [rankingListItemNameTextBase],
@@ -77,7 +78,7 @@ const tierBase = style({
   height: "auto",
 });
 
-export const tier = styleVariants<Record<string, ComplexStyleRule>>({
+export const tier = styleVariants<StyleVariantsType>({
   1: [tierBase, { width: "80px" }],
   2: [tierBase, { width: "70px" }],
   3: [tierBase, { width: "60px" }],

--- a/app/coin/style.css.ts
+++ b/app/coin/style.css.ts
@@ -1,5 +1,6 @@
 import { flex, font, theme } from "@/styles";
-import { ComplexStyleRule, style, styleVariants } from "@vanilla-extract/css";
+import StyleVariantsType from "@/types/styleVariants.interface";
+import { style, styleVariants } from "@vanilla-extract/css";
 
 export const informationContainer = style({
   width: "100%",
@@ -69,7 +70,7 @@ export const tradeToggleBase = style({
   },
 });
 
-export const tradeToggle = styleVariants<Record<string, ComplexStyleRule>>({
+export const tradeToggle = styleVariants<StyleVariantsType>({
   BUY: [tradeToggleBase, { borderBottom: `3px solid ${theme.buy}`, color: theme.buy }],
   SELL: [tradeToggleBase, { borderBottom: `3px solid ${theme.sell}`, color: theme.sell }],
   DISABLED: [tradeToggleBase, { borderBottom: `3px solid transparent`, color: theme.gray }],

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -1,4 +1,5 @@
 import EditorContainer from "@/components/Editor";
+import { EditorType } from "@/enum";
 import { generateOpenGraph } from "@/utils";
 
 export const metadata = generateOpenGraph({
@@ -7,7 +8,7 @@ export const metadata = generateOpenGraph({
 });
 
 const Page = () => {
-  return <EditorContainer mode="CREATE" />;
+  return <EditorContainer mode={EditorType.CREATE} />;
 };
 
 export default Page;

--- a/app/edit/[title]/page.tsx
+++ b/app/edit/[title]/page.tsx
@@ -1,5 +1,6 @@
 import getQueryClient from "@/app/getQueryClient";
 import EditorContainer from "@/components/Editor";
+import { EditorType } from "@/enum";
 import { docsQuery } from "@/services/docs/docs.query";
 import { generateOpenGraph } from "@/utils";
 import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
@@ -27,7 +28,7 @@ const Page = async ({ params: { title } }: PageProps) => {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <EditorContainer title={title} mode="EDIT" />
+      <EditorContainer title={title} mode={EditorType.EDIT} />
     </HydrationBoundary>
   );
 };

--- a/app/globals.css
+++ b/app/globals.css
@@ -153,26 +153,3 @@ button {
   width: 400px;
   color: #274168;
 }
-
-.subtitle {
-  color: #274168;
-  margin-top: 20px;
-  font-size: 28px;
-  font-weight: 700;
-  font-family: "Pretendard", sans-serif;
-}
-
-@keyframes spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
-.spin {
-  width: "50px";
-  display: inline-block;
-  animation: spin 0.6s linear infinite;
-}

--- a/app/history/[title]/detail/[id]/style.css.ts
+++ b/app/history/[title]/detail/[id]/style.css.ts
@@ -1,5 +1,6 @@
 import { flex, font, theme } from "@/styles";
-import { ComplexStyleRule, style, styleVariants } from "@vanilla-extract/css";
+import StyleVariantsType from "@/types/styleVariants.interface";
+import { style, styleVariants } from "@vanilla-extract/css";
 
 export const container = style({
   width: "100%",
@@ -34,7 +35,7 @@ const historyBase = style({
   ...flex.VERTICAL,
 });
 
-export const history = styleVariants<Record<string, ComplexStyleRule>>({
+export const history = styleVariants<StyleVariantsType>({
   INSERT: [historyBase, { background: theme.insert }],
   DELETE: [historyBase, { background: theme.delete }],
   EQUAL: [historyBase, { background: theme.equal }],
@@ -46,7 +47,7 @@ const historyOperationBase = style({
   ...flex.CENTER,
 });
 
-export const historyOperation = styleVariants<Record<string, ComplexStyleRule>>({
+export const historyOperation = styleVariants<StyleVariantsType>({
   INSERT: [historyOperationBase, { background: theme.insert }],
   DELETE: [historyOperationBase, { background: theme.delete }],
   EQUAL: [historyOperationBase, { background: theme.equal }],

--- a/components/(modal)/style.css.ts
+++ b/components/(modal)/style.css.ts
@@ -1,5 +1,6 @@
 import { flex, font, theme } from "@/styles";
-import { ComplexStyleRule, style, styleVariants } from "@vanilla-extract/css";
+import StyleVariantsType from "@/types/styleVariants.interface";
+import { style, styleVariants } from "@vanilla-extract/css";
 
 export const background = style({
   width: "100vw",
@@ -47,7 +48,7 @@ const buttonBase = style({
   ...font.btn1,
 });
 
-export const button = styleVariants<Record<string, ComplexStyleRule>>({
+export const button = styleVariants<StyleVariantsType>({
   confirm: [buttonBase, { backgroundColor: theme.primary, color: theme.white }],
   cancel: [buttonBase, { backgroundColor: theme.line, color: theme.black }],
 });

--- a/components/DragDropUpload/index.tsx
+++ b/components/DragDropUpload/index.tsx
@@ -8,66 +8,69 @@ const DragDropUpload: FC<{
   const down = useRef(false);
   const [dragging, setDragging] = useState(false);
 
-  useEffect(function setDragDropEvent() {
-    const onDrop = (e: DragEvent) => {
-      e.preventDefault();
+  useEffect(
+    function setDragDropEvent() {
+      const onDrop = (e: DragEvent) => {
+        e.preventDefault();
 
-      const { files } = e.dataTransfer || { files: null };
-      if (!files) return;
-      dragIndexRef.current = 0;
-      onUpload(files[0]);
-      setDragging(false);
-    };
+        const { files } = e.dataTransfer || { files: null };
+        if (!files) return;
+        dragIndexRef.current = 0;
+        onUpload(files[0]);
+        setDragging(false);
+      };
 
-    const onMouseDown = () => {
-      down.current = true;
-    };
+      const onMouseDown = () => {
+        down.current = true;
+      };
 
-    const onMouseUp = () => {
-      down.current = false;
-    };
+      const onMouseUp = () => {
+        down.current = false;
+      };
 
-    const onDragEnter = () => {
-      if (down.current) return;
-      if (!dragIndexRef.current) setDragging(true);
-      dragIndexRef.current += 1;
-    };
+      const onDragEnter = () => {
+        if (down.current) return;
+        if (!dragIndexRef.current) setDragging(true);
+        dragIndexRef.current += 1;
+      };
 
-    const onDragOver = (e: DragEvent) => {
-      e.preventDefault();
-      const { dataTransfer } = e;
-      if (dataTransfer) dataTransfer.dropEffect = "copy";
-      if (!dragging) setDragging(true);
-    };
+      const onDragOver = (e: DragEvent) => {
+        e.preventDefault();
+        const { dataTransfer } = e;
+        if (dataTransfer) dataTransfer.dropEffect = "copy";
+        if (!dragging) setDragging(true);
+      };
 
-    const onDragLeave = () => {
-      if (down.current) return;
-      if (dragIndexRef.current === 1) setDragging(false);
-      dragIndexRef.current -= 1;
-    };
+      const onDragLeave = () => {
+        if (down.current) return;
+        if (dragIndexRef.current === 1) setDragging(false);
+        dragIndexRef.current -= 1;
+      };
 
-    const onMouseLeave = () => {
-      if (dragging) setDragging(false);
-    };
+      const onMouseLeave = () => {
+        if (dragging) setDragging(false);
+      };
 
-    window.addEventListener("drop", onDrop);
-    window.addEventListener("dragover", onDragOver);
-    window.addEventListener("dragenter", onDragEnter);
-    window.addEventListener("dragleave", onDragLeave);
-    window.addEventListener("mousedown", onMouseDown);
-    window.addEventListener("mouseup", onMouseUp);
-    document.addEventListener("mouseleave", onMouseLeave);
+      window.addEventListener("drop", onDrop);
+      window.addEventListener("dragover", onDragOver);
+      window.addEventListener("dragenter", onDragEnter);
+      window.addEventListener("dragleave", onDragLeave);
+      window.addEventListener("mousedown", onMouseDown);
+      window.addEventListener("mouseup", onMouseUp);
+      document.addEventListener("mouseleave", onMouseLeave);
 
-    return () => {
-      window.removeEventListener("drop", onDrop);
-      window.removeEventListener("dragover", onDragOver);
-      window.removeEventListener("dragenter", onDragEnter);
-      window.removeEventListener("dragleave", onDragLeave);
-      window.removeEventListener("mousedown", onMouseDown);
-      window.removeEventListener("mouseup", onMouseUp);
-      document.removeEventListener("mouseleave", onMouseLeave);
-    };
-  }, [dragging, onUpload]);
+      return () => {
+        window.removeEventListener("drop", onDrop);
+        window.removeEventListener("dragover", onDragOver);
+        window.removeEventListener("dragenter", onDragEnter);
+        window.removeEventListener("dragleave", onDragLeave);
+        window.removeEventListener("mousedown", onMouseDown);
+        window.removeEventListener("mouseup", onMouseUp);
+        document.removeEventListener("mouseleave", onMouseLeave);
+      };
+    },
+    [dragging, onUpload],
+  );
 
   if (dragging)
     return (

--- a/components/DragDropUpload/index.tsx
+++ b/components/DragDropUpload/index.tsx
@@ -9,75 +9,78 @@ const DragDropUpload: FC<DragDropUploadProps> = ({ onUpload }) => {
   const down = useRef(false);
   const [dragging, setDragging] = useState(false);
 
-  useEffect(() => {
-    const onDrop = (e: DragEvent) => {
-      e.preventDefault();
-      const { files } = e.dataTransfer || { files: null };
-      if (!files) return;
-      if (!files[0]) return;
-      onUpload(files[0]);
+  useEffect(
+    function setEvent() {
+      const onDrop = (e: DragEvent) => {
+        e.preventDefault();
+        const { files } = e.dataTransfer || { files: null };
+        if (!files) return;
+        if (!files[0]) return;
+        onUpload(files[0]);
 
-      dragIndex.current = 0;
-      setDragging(false);
-      e.stopPropagation();
-    };
-
-    const onMouseDown = () => {
-      down.current = true;
-    };
-    const onMouseUp = () => {
-      down.current = false;
-    };
-    const onDragEnter = () => {
-      if (down.current) return;
-      dragIndex.current += 1;
-      if (dragIndex.current === 1) {
-        setDragging(true);
-      }
-    };
-
-    const onDragOver = (e: DragEvent) => {
-      e.preventDefault();
-      if (e.dataTransfer) {
-        e.dataTransfer.dropEffect = "copy";
-      }
-      if (!dragging) {
-        setDragging(true);
-      }
-    };
-
-    const onDragLeave = () => {
-      if (down.current) return;
-      dragIndex.current -= 1;
-      if (dragIndex.current === 0) {
+        dragIndex.current = 0;
         setDragging(false);
-      }
-    };
+        e.stopPropagation();
+      };
 
-    const onMouseLeave = () => {
-      if (dragging) {
-        setDragging(false);
-      }
-    };
+      const onMouseDown = () => {
+        down.current = true;
+      };
+      const onMouseUp = () => {
+        down.current = false;
+      };
+      const onDragEnter = () => {
+        if (down.current) return;
+        dragIndex.current += 1;
+        if (dragIndex.current === 1) {
+          setDragging(true);
+        }
+      };
 
-    window.addEventListener("drop", onDrop);
-    window.addEventListener("dragover", onDragOver);
-    window.addEventListener("mousedown", onMouseDown);
-    window.addEventListener("mouseup", onMouseUp);
-    window.addEventListener("dragenter", onDragEnter);
-    window.addEventListener("dragleave", onDragLeave);
-    document.addEventListener("mouseleave", onMouseLeave);
+      const onDragOver = (e: DragEvent) => {
+        e.preventDefault();
+        if (e.dataTransfer) {
+          e.dataTransfer.dropEffect = "copy";
+        }
+        if (!dragging) {
+          setDragging(true);
+        }
+      };
 
-    return () => {
-      window.removeEventListener("drop", onDrop);
-      window.removeEventListener("dragover", onDragOver);
-      window.removeEventListener("mousedown", onMouseDown);
-      window.removeEventListener("mouseup", onMouseUp);
-      window.removeEventListener("dragenter", onDragEnter);
-      window.removeEventListener("dragleave", onDragLeave);
-      document.removeEventListener("mouseleave", onMouseLeave);
-    };
-  }, [dragging, onUpload]);
+      const onDragLeave = () => {
+        if (down.current) return;
+        dragIndex.current -= 1;
+        if (dragIndex.current === 0) {
+          setDragging(false);
+        }
+      };
+
+      const onMouseLeave = () => {
+        if (dragging) {
+          setDragging(false);
+        }
+      };
+
+      window.addEventListener("drop", onDrop);
+      window.addEventListener("dragover", onDragOver);
+      window.addEventListener("mousedown", onMouseDown);
+      window.addEventListener("mouseup", onMouseUp);
+      window.addEventListener("dragenter", onDragEnter);
+      window.addEventListener("dragleave", onDragLeave);
+      document.addEventListener("mouseleave", onMouseLeave);
+
+      return () => {
+        window.removeEventListener("drop", onDrop);
+        window.removeEventListener("dragover", onDragOver);
+        window.removeEventListener("mousedown", onMouseDown);
+        window.removeEventListener("mouseup", onMouseUp);
+        window.removeEventListener("dragenter", onDragEnter);
+        window.removeEventListener("dragleave", onDragLeave);
+        document.removeEventListener("mouseleave", onMouseLeave);
+      };
+    },
+    [dragging, onUpload],
+  );
 
   return dragging ? (
     <div className={styles.dragDropUploadBlock}>

--- a/components/Editor/DocsExample.css.ts
+++ b/components/Editor/DocsExample.css.ts
@@ -1,0 +1,74 @@
+import { flex, font, theme } from "@/styles";
+import StyleVariantsType from "@/types/styleVariants.interface";
+import { style, styleVariants } from "@vanilla-extract/css";
+
+const wikiBoxHeaderBase = style({
+  width: "100%",
+  height: "fit-content",
+  backgroundColor: theme.primary,
+  left: 0,
+  bottom: 0,
+  position: "fixed",
+  padding: "10px 24px",
+  cursor: "pointer",
+  ...flex.BETWEEN,
+});
+
+export const wikiBoxHeader = styleVariants<StyleVariantsType>({
+  true: [wikiBoxHeaderBase, { bottom: "260px" }],
+  false: [wikiBoxHeaderBase, { bottom: 0 }],
+});
+
+export const wikiTitle = style({
+  color: theme.white,
+  ...font.H5,
+});
+
+const tCellBase = style({
+  width: "100%",
+  height: "100%",
+  padding: "4px 12px",
+  ...flex.VERTICAL,
+});
+
+export const footer = {
+  body: style({
+    width: "100%",
+    height: "260px",
+    left: 0,
+    bottom: 0,
+    position: "fixed",
+    background: theme.white,
+    ...flex.VERTICAL,
+  }),
+  wrap: style({
+    width: "100%",
+    height: "100%",
+    ...flex.COLUMN_FLEX,
+  }),
+  box: style({
+    width: "100%",
+    height: "100%",
+    border: `1px solid ${theme.gray}`,
+    ...flex.VERTICAL,
+  }),
+  tHead: style({
+    width: "18%",
+    height: "100%",
+    borderRight: `1px solid ${theme.gray}`,
+    color: theme.white,
+    backgroundColor: theme.primary,
+    textAlign: "center",
+    ...flex.CENTER,
+  }),
+  tItem: style({
+    width: "82%",
+    cursor: "pointer",
+    height: "100%",
+    ...flex.COLUMN_FLEX,
+  }),
+  tCell: styleVariants<StyleVariantsType>({
+    top: [tCellBase, { borderBottom: `2px solid ${theme.gray}` }],
+    bottom: [tCellBase],
+  }),
+};

--- a/components/Editor/DocsExample.tsx
+++ b/components/Editor/DocsExample.tsx
@@ -3,7 +3,58 @@ import { toast } from "react-toastify";
 import { ArrowIcon } from "@/assets";
 import { documentCompiler } from "@/utils";
 import Toastify from "../Toastify";
-import * as styles from "./style.css";
+import * as styles from "./DocsExample.css";
+
+const DocsExample = () => {
+  const [isExampleOpen, setIsExampleOpen] = useState(false);
+  const arrowDirection = isExampleOpen ? "down" : "up";
+
+  const handleTagCopyClick = async (tag: string) => {
+    await navigator.clipboard.writeText(`<${tag}></${tag}>`);
+    toast(<Toastify content="클립보드에 복사되었어요!" />);
+  };
+
+  return (
+    <>
+      <header
+        onClick={() => setIsExampleOpen((prev) => !prev)}
+        className={styles.wikiBoxHeader[String(isExampleOpen)]}
+      >
+        <span className={styles.wikiTitle}>부마위키 문법 예제 보기</span>
+        <ArrowIcon
+          direction={arrowDirection}
+          fill="white"
+          width={16}
+          height={16}
+          viewBox="0 0 30 16"
+        />
+      </header>
+      {isExampleOpen && (
+        <section className={styles.footer.body}>
+          {wikiExampleList.map((list, index) => (
+            <ul className={styles.footer.wrap} key={index}>
+              {list.map((ex) => (
+                <li className={styles.footer.box} key={ex.name}>
+                  <hgroup className={styles.footer.tHead}>{ex.name}</hgroup>
+                  <section
+                    className={styles.footer.tItem}
+                    onClick={() => handleTagCopyClick(ex.name)}
+                  >
+                    <figure className={styles.footer.tCell.top}>{ex.example}</figure>
+                    <figure
+                      className={styles.footer.tCell.bottom}
+                      dangerouslySetInnerHTML={{ __html: documentCompiler(ex.example) }}
+                    />
+                  </section>
+                </li>
+              ))}
+            </ul>
+          ))}
+        </section>
+      )}
+    </>
+  );
+};
 
 const wikiExampleList = [
   [
@@ -32,55 +83,4 @@ const wikiExampleList = [
     },
   ],
 ];
-
-const DocsExample = () => {
-  const [isExampleOpen, setIsExampleOpen] = useState(false);
-  const handleTagCopyClick = async (tag: string) => {
-    await navigator.clipboard.writeText(`<${tag}></${tag}>`);
-    toast(<Toastify content="클립보드에 복사되었어요!" />);
-  };
-
-  return (
-    <>
-      <header
-        onClick={() => setIsExampleOpen((prev) => !prev)}
-        className={styles.wikiBoxHeader[String(isExampleOpen)]}
-      >
-        <span className={styles.wikiTitle}>부마위키 문법 예제 보기</span>
-        <ArrowIcon
-          direction={isExampleOpen ? "down" : "up"}
-          fill="white"
-          width={16}
-          height={16}
-          viewBox="0 0 30 16"
-        />
-      </header>
-      {isExampleOpen && (
-        <main className={styles.footer.body}>
-          {wikiExampleList.map((list, index) => (
-            <div className={styles.footer.wrap} key={index}>
-              {list.map((ex) => (
-                <article className={styles.footer.box} key={ex.name}>
-                  <hgroup className={styles.footer.tHead}>{ex.name}</hgroup>
-                  <section
-                    className={styles.footer.tItem}
-                    onClick={() => handleTagCopyClick(ex.name)}
-                  >
-                    <figure className={styles.footer.tCell.top}>{ex.example}</figure>
-                    <figure
-                      className={styles.footer.tCell.bottom}
-                      // eslint-disable-next-line react/no-danger
-                      dangerouslySetInnerHTML={{ __html: documentCompiler(ex.example) }}
-                    />
-                  </section>
-                </article>
-              ))}
-            </div>
-          ))}
-        </main>
-      )}
-    </>
-  );
-};
-
 export default DocsExample;

--- a/components/Editor/Editor.tsx
+++ b/components/Editor/Editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChangeEvent, memo, useCallback, useState } from "react";
+import { createElement, memo, useCallback, useState } from "react";
 import {
   useCreateDocsMutation,
   useUploadImageMutation,
@@ -14,6 +14,7 @@ import { AxiosError } from "axios";
 import { autoClosingTag, documentCompiler } from "@/utils";
 import { CLASSIFY } from "@/record/docsType.record";
 import { useDate } from "@/hooks/useDate";
+import { EditorType } from "@/enum";
 import DragDropUpload from "../DragDropUpload";
 import PasteUpload from "../PasteUpload";
 import FrameEditor from "../FrameEditor";
@@ -25,7 +26,7 @@ interface EditorProps {
   contents?: string;
   title?: string;
   docsType?: string;
-  mode: "EDIT" | "CREATE";
+  mode: EditorType.EDIT | EditorType.CREATE;
 }
 
 const Editor = memo(({ contents = "", title = "", docsType = "", mode }: EditorProps) => {
@@ -44,6 +45,20 @@ const Editor = memo(({ contents = "", title = "", docsType = "", mode }: EditorP
     contents: contents.replaceAll("<br>", "\n"),
     docsType,
   });
+  const isFrame = docs.docsType === "FRAME";
+
+  const uploadImage = async (file: File) => {
+    if (!file) return;
+    const { url } = await upload(file);
+    setIsChanged((prev) => !prev);
+    const position = isFrame && cursorPosition === 0 ? 26 : cursorPosition;
+    const beforeContent = docs.contents.substring(0, position);
+    const imageTag = `<사진 {200px}>${url}</사진>`;
+    const afterContent = docs.contents.substring(position, docs.contents.length);
+    setDocs({ ...docs, contents: `${beforeContent}${imageTag}${afterContent}` });
+  };
+
+  const handleDragDropUpload = useCallback((file: File) => uploadImage(file), [uploadImage]);
 
   const handleOpenConfirm = () => {
     if (contents !== docs.contents.trim()) {
@@ -57,40 +72,17 @@ const Editor = memo(({ contents = "", title = "", docsType = "", mode }: EditorP
     }
   };
 
-  const uploadImage = async (file: File) => {
-    if (!file) return;
-    const { url } = await upload(file);
-    setIsChanged((prev) => !prev);
-    const position =
-      ["틀", "FRAME"].includes(docs.docsType) && cursorPosition === 0 ? 26 : cursorPosition;
-    const first = docs.contents.substring(0, position);
-    const middle = `<사진 {200px}>${url}</사진>`;
-    const last = docs.contents.substring(position, docs.contents.length);
-
-    setDocs({ ...docs, contents: `${first}${middle}${last}` });
-  };
-
-  const handleDragDropUpload = useCallback((file: File) => uploadImage(file), [uploadImage]);
-
-  const handleDocsContentsChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    setDocs((prev) => ({ ...prev, contents: autoClosingTag(e).replaceAll("<br>", "\n") }));
-  };
-
   const handleCreateDocsClick = async () => {
     if (!docs.title.trim()) return openToast("제목을 입력해주세요!");
     if (!docs.enroll) return openToast("문서 연도를 선택해주세요!");
     if (!docs.docsType) return openToast("문서 분류를 선택해주세요!");
     if (!docs.contents.trim()) return openToast("내용을 입력해주세요!");
 
-    const isInvalidTitle =
-      docs.title.includes("#") ||
-      docs.title.includes("?") ||
-      docs.title.includes("/") ||
-      docs.title.includes("\\") ||
-      docs.title.includes("%");
-    if (isInvalidTitle) return openToast("문서명에는 #, ?, /를 넣을 수 없습니다.");
+    const invalidCharacters = ["#", "?", "/", "\\", "%"];
+    const isInvalidTitle = invalidCharacters.some((char) => docs.title.includes(char));
+    if (isInvalidTitle)
+      return openToast(`문서명에는 ${invalidCharacters.join(" ")} 기호를 넣을 수 없습니다.`);
 
-    docs.docsType = CLASSIFY[docs.docsType];
     await create(docs, {
       onSuccess: () => {
         queryClient.invalidateQueries(docsQuery.list(docs.docsType.toLowerCase()));
@@ -121,7 +113,7 @@ const Editor = memo(({ contents = "", title = "", docsType = "", mode }: EditorP
   };
 
   const setDocsType = (selectedDocsType: string) => {
-    if (docs.docsType === "틀") setDocs((prev) => ({ ...prev, contents: "" }));
+    if (isFrame) setDocs((prev) => ({ ...prev, contents: "" }));
     setDocs((prev) => ({ ...prev, docsType: selectedDocsType }));
   };
 
@@ -134,51 +126,50 @@ const Editor = memo(({ contents = "", title = "", docsType = "", mode }: EditorP
             value={docs.title}
             placeholder="제목을 입력해주세요"
             className={styles.titleInput}
-            disabled={mode === "EDIT"}
+            disabled={mode === EditorType.EDIT}
           />
-          {mode === "EDIT" ? (
+          {mode === EditorType.EDIT ? (
             <button onClick={handleOpenConfirm} className={styles.undoBtn}>
               되돌리기
             </button>
           ) : (
-            <>
-              <div className={styles.enrollList}>
-                |
-                {getValidYearList().map((year) => (
-                  <div key={year}>
-                    <span
-                      onClick={() => setDocs((prev) => ({ ...prev, enroll: year }))}
-                      className={styles.year[String(year === docs.enroll)]}
-                    >
-                      &nbsp;{year}&nbsp;
-                    </span>
-                    |
-                  </div>
-                ))}
-              </div>
-              <div className={styles.separator} />
-              <div className={styles.docsTypeList}>
-                {[
-                  "사건/사고",
-                  "보통교과 선생님",
-                  "전공교과 선생님",
-                  "멘토 선생님",
-                  "전공 동아리",
-                  "사설 동아리",
-                  "틀",
-                ].map((type) => (
-                  <button
-                    onClick={() => setDocsType(type)}
-                    key={type}
-                    className={styles.docsType[String(type === docs.docsType)]}
-                  >
-                    {type}
-                  </button>
-                ))}
-              </div>
-            </>
+            (function SelectEnrollAndDocsTypeComponent() {
+              return (
+                <>
+                  <section className={styles.enrollList}>
+                    {getValidYearList().map((year) => (
+                      <span
+                        key={year}
+                        onClick={() => setDocs((prev) => ({ ...prev, enroll: year }))}
+                      >
+                        &nbsp;<b className={styles.year[String(year === docs.enroll)]}>{year}</b> |
+                      </span>
+                    ))}
+                  </section>
+                  <section className={styles.docsTypeList}>
+                    {[
+                      "ACCIDENT",
+                      "TEACHER",
+                      "MAJOR_TEACHER",
+                      "MENTOR_TEACHER",
+                      "CLUB",
+                      "FREE_CLUB",
+                      "FRAME",
+                    ].map((type) => (
+                      <button
+                        onClick={() => setDocsType(type)}
+                        key={type}
+                        className={styles.docsType[String(type === docs.docsType)]}
+                      >
+                        {CLASSIFY[type]}
+                      </button>
+                    ))}
+                  </section>
+                </>
+              );
+            })()
           )}
-          {["틀", "FRAME"].includes(docs.docsType) ? (
+          {isFrame ? (
             <FrameEditor
               mode={mode}
               docs={docs}
@@ -189,7 +180,7 @@ const Editor = memo(({ contents = "", title = "", docsType = "", mode }: EditorP
           ) : (
             <textarea
               onKeyDown={(e) => setCursorPosition((e.target as HTMLTextAreaElement).selectionStart)}
-              onChange={handleDocsContentsChange}
+              onChange={(e) => setDocs((prev) => ({ ...prev, contents: autoClosingTag(e) }))}
               value={docs.contents}
               placeholder="문서 내용을 입력해주세요. 사진 또는 동영상을 넣으려면 파일을 드래그&드롭하세요."
               className={styles.textarea}
@@ -200,35 +191,25 @@ const Editor = memo(({ contents = "", title = "", docsType = "", mode }: EditorP
           <h1 className={styles.previewTitle}>{docs.title}</h1>
           {docs.docsType && (
             <div className={styles.classifyBox}>
-              분류 : <span className={styles.classify}>{docs.docsType}</span>
+              분류 : <span className={styles.classify}>{CLASSIFY[docs.docsType]}</span>
             </div>
           )}
-          {["틀", "FRAME"].includes(docs.docsType) ? (
-            <section className={styles.preview}>
-              <FrameEncoder
-                title={docs.title}
-                contents={docs.contents}
-                docsType={docs.docsType}
-                mode="WRITE"
-              />
-            </section>
-          ) : (
-            <section
-              className={styles.preview}
-              dangerouslySetInnerHTML={{
-                __html: documentCompiler(docs.contents),
-              }}
-            />
+          {createElement(
+            "section",
+            {
+              class: styles.preview,
+              dangerouslySetInnerHTML: isFrame ? null : { __html: documentCompiler(docs.contents) },
+            },
+            isFrame ? <FrameEncoder {...docs} mode="WRITE" /> : null,
           )}
         </section>
-        {mode === "EDIT" ? (
-          <button onClick={handleEditDocsClick} className={styles.writeButton}>
-            편집하기
-          </button>
-        ) : (
-          <button onClick={handleCreateDocsClick} className={styles.writeButton}>
-            생성하기
-          </button>
+        {createElement(
+          "button",
+          {
+            class: styles.writeButton,
+            onClick: mode === EditorType.EDIT ? handleEditDocsClick : handleCreateDocsClick,
+          },
+          mode === EditorType.EDIT ? "편집하기" : "생성하기",
         )}
         <DocsExample />
       </main>

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -7,7 +7,7 @@ import { EditorType } from "@/enum";
 import Editor from "./Editor";
 
 type EditMode = { mode: EditorType.EDIT; title: string };
-type CreateMode = { mode: EditorType.CREATE; title: undefined };
+type CreateMode = { mode: EditorType.CREATE; title?: undefined };
 
 const EditorContainer: FC<EditMode | CreateMode> = ({ title, mode }) => {
   const { data, isSuccess } = useQuery({

--- a/components/Editor/index.tsx
+++ b/components/Editor/index.tsx
@@ -3,17 +3,18 @@
 import { FC } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { docsQuery } from "@/services/docs/docs.query";
+import { EditorType } from "@/enum";
 import Editor from "./Editor";
 
-type EditMode = { mode: "EDIT"; title: string };
-type CreateMode = { mode: "CREATE"; title?: undefined };
+type EditMode = { mode: EditorType.EDIT; title: string };
+type CreateMode = { mode: EditorType.CREATE; title: undefined };
 
 const EditorContainer: FC<EditMode | CreateMode> = ({ title, mode }) => {
   const { data, isSuccess } = useQuery({
     ...docsQuery.title(title as string),
-    enabled: mode === "EDIT",
+    enabled: mode === EditorType.EDIT,
   });
-  const docs = isSuccess ? { ...data } : { title: "", contents: "", docsType: "" };
+  const docs = isSuccess ? data : { title: "", contents: "", docsType: "" };
 
   return <Editor {...docs} mode={mode} />;
 };

--- a/components/Editor/style.css.ts
+++ b/components/Editor/style.css.ts
@@ -76,10 +76,15 @@ export const enrollList = style({
   color: theme.boldgray,
   ...flex.VERTICAL,
   ...font.H3_1,
+
+  ":before": {
+    content: "|",
+  },
 });
 
 const yearBase = style({
   cursor: "pointer",
+  ...font.H4,
 
   ":hover": {
     color: theme.primary,

--- a/components/Editor/style.css.ts
+++ b/components/Editor/style.css.ts
@@ -1,5 +1,6 @@
 import { flex, font, theme } from "@/styles";
-import { ComplexStyleRule, style, styleVariants } from "@vanilla-extract/css";
+import StyleVariantsType from "@/types/styleVariants.interface";
+import { style, styleVariants } from "@vanilla-extract/css";
 
 export const container = style({
   width: "100%",
@@ -85,7 +86,7 @@ const yearBase = style({
   },
 });
 
-export const year = styleVariants<Record<string, ComplexStyleRule>>({
+export const year = styleVariants<StyleVariantsType>({
   true: [yearBase, { color: theme.primary }],
   false: [yearBase, { color: theme.boldgray }],
 });
@@ -119,7 +120,7 @@ const docsTypeBase = style({
   ...font.btn3,
 });
 
-export const docsType = styleVariants<Record<string, ComplexStyleRule>>({
+export const docsType = styleVariants<StyleVariantsType>({
   true: [docsTypeBase, { background: theme.primary, color: theme.white }],
   false: [docsTypeBase, { background: theme.preview, color: theme.primary }],
 });
@@ -131,77 +132,6 @@ export const textarea = style({
   marginTop: "12px",
   ...font.p1,
 });
-
-const wikiBoxHeaderBase = style({
-  width: "100%",
-  height: "fit-content",
-  backgroundColor: theme.primary,
-  left: 0,
-  bottom: 0,
-  position: "fixed",
-  padding: "10px 24px",
-  cursor: "pointer",
-  ...flex.BETWEEN,
-});
-
-export const wikiBoxHeader = styleVariants<Record<string, ComplexStyleRule>>({
-  true: [wikiBoxHeaderBase, { bottom: "260px" }],
-  false: [wikiBoxHeaderBase, { bottom: 0 }],
-});
-
-export const wikiTitle = style({
-  color: theme.white,
-  ...font.H5,
-});
-
-const tCellBase = style({
-  width: "100%",
-  height: "100%",
-  padding: "4px 12px",
-  ...flex.VERTICAL,
-});
-
-export const footer = {
-  body: style({
-    width: "100%",
-    height: "260px",
-    left: 0,
-    bottom: 0,
-    position: "fixed",
-    background: theme.white,
-    ...flex.VERTICAL,
-  }),
-  wrap: style({
-    width: "100%",
-    height: "100%",
-    ...flex.COLUMN_FLEX,
-  }),
-  box: style({
-    width: "100%",
-    height: "100%",
-    border: `1px solid ${theme.gray}`,
-    ...flex.VERTICAL,
-  }),
-  tHead: style({
-    width: "18%",
-    height: "100%",
-    borderRight: `1px solid ${theme.gray}`,
-    color: theme.white,
-    backgroundColor: theme.primary,
-    textAlign: "center",
-    ...flex.CENTER,
-  }),
-  tItem: style({
-    width: "82%",
-    cursor: "pointer",
-    height: "100%",
-    ...flex.COLUMN_FLEX,
-  }),
-  tCell: styleVariants<Record<string, ComplexStyleRule>>({
-    top: [tCellBase, { borderBottom: `2px solid ${theme.gray}` }],
-    bottom: [tCellBase],
-  }),
-};
 
 export const writeButton = style({
   position: "fixed",

--- a/components/FrameEncoder/index.tsx
+++ b/components/FrameEncoder/index.tsx
@@ -41,10 +41,7 @@ const FrameEncoder = ({ title, contents, docsType, mode }: DocsPropsType) => {
                   style={{ borderColor: theme }}
                   aria-label="present td's content"
                 >
-                  <div
-                    // eslint-disable-next-line react/no-danger
-                    dangerouslySetInnerHTML={{ __html: documentCompiler(col.content) }}
-                  />
+                  <div dangerouslySetInnerHTML={{ __html: documentCompiler(col.content) }} />
                 </td>
               ))}
             </tr>

--- a/enum/editorType.enum.ts
+++ b/enum/editorType.enum.ts
@@ -1,0 +1,6 @@
+enum EditorType {
+  EDIT = "EDIT",
+  CREATE = "CREATE",
+}
+
+export default EditorType;

--- a/enum/index.ts
+++ b/enum/index.ts
@@ -1,0 +1,1 @@
+export { default as EditorType } from "./editorType.enum";

--- a/hooks/useModal.tsx
+++ b/hooks/useModal.tsx
@@ -2,6 +2,8 @@ import { ReactNode, useCallback } from "react";
 import { useSetAtom } from "jotai";
 import { modalContext } from "@/context/index";
 import Confirm from "@/components/(modal)/Confirm";
+import { toast } from "react-toastify";
+import Toastify from "@/components/Toastify";
 
 const useModal = () => {
   const setModal = useSetAtom(modalContext);
@@ -20,11 +22,16 @@ const useModal = () => {
     [setModal],
   );
 
+  const openToast = useCallback(
+    (content: string) => toast(<Toastify content={content} />),
+    [setModal],
+  );
+
   const closeModal = useCallback(() => {
     setModal({ component: null, visible: false });
   }, [setModal]);
 
-  return { openModal, openConfirm, closeModal };
+  return { openModal, openConfirm, openToast, closeModal };
 };
 
 export default useModal;

--- a/styles/document.css.ts
+++ b/styles/document.css.ts
@@ -3,7 +3,7 @@ import { theme, font, flex } from ".";
 
 export const details = style({
   width: "100%",
-  paddingBottom: "50px",
+  paddingBottom: "10px",
 });
 
 export const summary = style({

--- a/types/styleVariants.interface.ts
+++ b/types/styleVariants.interface.ts
@@ -1,0 +1,5 @@
+import { ComplexStyleRule } from "@vanilla-extract/css";
+
+type StyleVariantsType = Record<string, ComplexStyleRule>;
+
+export default StyleVariantsType;


### PR DESCRIPTION
## What
editor를 리팩터링했습니다.

## How
- frame인지 판별하는 조건문을 캡슐화했습니다.
- includes를 나열하여 캡슐화해놓았던 isInvalidTitle 변수를 some을 사용하여 최적화했습니다.
- "틀", "FRAME"이 혼동되어 비교문에서 includes를 사용하였으나, 이를 record를 사용해서 깔끔하게 처리했습니다.
- "EDIT", "CREATE"로 되어있던 변수들을 enum을 사용하여 처리했습니다.
- 기존에 이름이 없던 조건부 jsx element를 묵시적실행함수를 사용하여 SelectEnrollAndDocsTypeComponent 네이밍을 부여했습니다.
- 같은 태그와 className을 사용하지만 element 내용만 다른 삼항연산자 컴포넌트들을 createElement를 사용하여 최적화했습니다.

## ScreenShot

<img width="352" alt="스크린샷 2024-04-10 오후 4 38 35" src="https://github.com/Team-INSERT/BUMAWIKI_WEB_V3/assets/102154880/533795e8-36f3-482a-b474-eeec3698c433">

위 : 리팩터링 후, 아래 : 리팩토링 전