### PR TITLE
refactor : PasteUpload 리팩터링

### DIFF
--- a/components/PasteUpload/index.tsx
+++ b/components/PasteUpload/index.tsx
@@ -7,33 +7,33 @@ export interface PasteUploadProps {
 const PasteUpload: FC<PasteUploadProps> = ({ onUpload }) => {
   useEffect(() => {
     const onPaste: EventListener = (e) => {
+      e.preventDefault();
       const { clipboardData } = e as ClipboardEvent;
       if (!clipboardData) return;
 
       const { items } = clipboardData;
-      if (items.length === 0) return;
+      if (!items.length) return;
 
       const itemsArray = (() => {
         const array = [];
-        for (let i = 0; i < items.length; i += 1) {
-          array.push(items[i]);
-        }
+        for (let i = 0; i < items.length; i += 1) array.push(items[i]);
         return array;
       })();
 
-      const fileItem = itemsArray.filter((item) => item.kind === "file")[0];
+      const [fileItem] = itemsArray.filter((item) => item.kind === "file");
       if (!fileItem || !fileItem.getAsFile) return;
+
       const file = fileItem.getAsFile();
       if (!file) return;
       onUpload(file);
-      e.preventDefault();
     };
+
     window.addEventListener("paste", onPaste);
     return () => {
       window.removeEventListener("paste", onPaste);
     };
   }, [onUpload]);
-  return null;
+  return <></>;
 };
 
 export default PasteUpload;


### PR DESCRIPTION
## What
PasteUpload 컴포넌트를 리팩터링했습니다.

## How
- 구조분해할당을 통해 배열 index에 접근하지않고 값을 꺼낼 수 있게 변경했습니다.
- 자잘한 코드 스타일을 변경했습니다.

## ScreenShot
